### PR TITLE
[14.0] endpoint_product_catalog: fix view inheritance

### DIFF
--- a/endpoint_product_catalog/views/endpoint_endpoint.xml
+++ b/endpoint_product_catalog/views/endpoint_endpoint.xml
@@ -5,7 +5,7 @@
         <field name="model">endpoint.endpoint</field>
         <field name="inherit_id" ref="endpoint.endpoint_endpoint_form_view" />
         <field name="arch" type="xml">
-            <notebook position="inside">
+            <xpath expr="//page[last()]" position="after">
                 <page name="catalog" string="Catalog">
                     <group>
                         <group name="catalog_base_info">
@@ -20,7 +20,7 @@
                         </group>
                     </group>
                 </page>
-            </notebook>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
As the endpoint.endpoint form view does not really contain any element You must use xpath to find elements in the original hierarchy.